### PR TITLE
Updated typeguard to reasonable version

### DIFF
--- a/packages/jsii-pacmak/lib/targets/python.ts
+++ b/packages/jsii-pacmak/lib/targets/python.ts
@@ -2125,7 +2125,7 @@ class Package {
       install_requires: [
         `jsii${toPythonVersionRange(`^${VERSION}`)}`,
         'publication>=0.0.3',
-        'typeguard~=2.13.3',
+        'typeguard>=3.0.2',
       ]
         .concat(dependencies)
         .sort(),


### PR DESCRIPTION
Updated Python typeguard to reasonable new version
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
